### PR TITLE
fix(storyboard): 修复测试用例中的语法错误

### DIFF
--- a/server/src/test/java/com/novanovastudio/service/StoryboardAgentServiceTest.java
+++ b/server/src/test/java/com/novanovastudio/service/StoryboardAgentServiceTest.java
@@ -88,7 +88,7 @@ class StoryboardAgentServiceTest {
                         声音：Rainfall and distant thunder.
 
                         视觉风格：%s
-                        """.formatted(VISUAL_STYLE).trim()));
+                        """.formatted(VISUAL_STYLE).trim())));
 
         BusinessException exception = Assertions.assertThrows(BusinessException.class, () -> invokePromptValidation(shots, result));
 


### PR DESCRIPTION
- 修正了 StoryboardAgentServiceTest 中多余的右括号问题
- 确保测试方法 invokePromptValidation 的调用语法正确
- 维持原有测试逻辑不变，仅修复编译错误