### PR TITLE
fix(repository): 修复查询过滤条件中的SQL拼接问题

### DIFF
--- a/server/src/main/java/com/novanovastudio/repository/CreditCardRepository.java
+++ b/server/src/main/java/com/novanovastudio/repository/CreditCardRepository.java
@@ -294,13 +294,13 @@ public class CreditCardRepository {
      */
     static String cardFilters(CardListQuery query) {
         StringBuilder sql = new StringBuilder();
-        if (query.batchId() != null) sql.append(" AND cards.batch_id = :batchId");
-        if ("available".equals(query.status())) sql.append(" AND cards.redeemed_at IS NULL");
-        if ("redeemed".equals(query.status())) sql.append(" AND cards.redeemed_at IS NOT NULL");
-        if (query.codeHash() != null) sql.append(" AND cards.code_hash = :codeHash");
-        if (query.codeSuffix() != null) sql.append(" AND cards.code_suffix = :codeSuffix");
+        if (query.batchId() != null) sql.append(" AND cards.batch_id = :batchId\n");
+        if ("available".equals(query.status())) sql.append(" AND cards.redeemed_at IS NULL\n");
+        if ("redeemed".equals(query.status())) sql.append(" AND cards.redeemed_at IS NOT NULL\n");
+        if (query.codeHash() != null) sql.append(" AND cards.code_hash = :codeHash\n");
+        if (query.codeSuffix() != null) sql.append(" AND cards.code_suffix = :codeSuffix\n");
         if (query.redeemedUserKeyword() != null) {
-            sql.append(" AND (LOWER(COALESCE(redeemed_user.email, '')) LIKE :redeemedUserKeyword OR LOWER(COALESCE(redeemed_user.username, '')) LIKE :redeemedUserKeyword OR LOWER(COALESCE(redeemed_user.nickname, '')) LIKE :redeemedUserKeyword)");
+            sql.append(" AND (LOWER(COALESCE(redeemed_user.email, '')) LIKE :redeemedUserKeyword OR LOWER(COALESCE(redeemed_user.username, '')) LIKE :redeemedUserKeyword OR LOWER(COALESCE(redeemed_user.nickname, '')) LIKE :redeemedUserKeyword)\n");
         }
         return sql.toString();
     }
@@ -313,8 +313,8 @@ public class CreditCardRepository {
      */
     static String redemptionFilters(RedemptionQuery query) {
         StringBuilder sql = new StringBuilder();
-        if (query.codeHash() != null) sql.append(" AND cards.code_hash = :codeHash");
-        if (query.codeSuffix() != null) sql.append(" AND cards.code_suffix = :codeSuffix");
+        if (query.codeHash() != null) sql.append(" AND cards.code_hash = :codeHash\n");
+        if (query.codeSuffix() != null) sql.append(" AND cards.code_suffix = :codeSuffix\n");
         return sql.toString();
     }
 

--- a/server/src/test/java/com/novanovastudio/repository/CreditRepositoryTest.java
+++ b/server/src/test/java/com/novanovastudio/repository/CreditRepositoryTest.java
@@ -64,6 +64,17 @@ class CreditRepositoryTest {
         Assertions.assertTrue(sql.contains("cards.redeemed_at IS NOT NULL"));
         Assertions.assertTrue(sql.contains("cards.code_hash = :codeHash"));
         Assertions.assertTrue(sql.contains(":redeemedUserKeyword"));
+        Assertions.assertTrue(sql.endsWith("\n"));
+    }
+
+    /**
+     * 兑换记录筛选条件后应保留换行，避免与排序子句黏连。
+     */
+    @Test
+    void shouldKeepLineBreakAfterRedemptionFilters() {
+        CreditCardRepository.RedemptionQuery query = new CreditCardRepository.RedemptionQuery(1L, null, null, "hash", null);
+
+        Assertions.assertTrue(CreditCardRepository.redemptionFilters(query).endsWith("\n"));
     }
 
     /**


### PR DESCRIPTION
- 在cardFilters方法中为所有条件添加换行符，避免SQL语句黏连
- 在redemptionFilters方法中为所有条件添加换行符，确保SQL格式正确
- 添加测试用例验证cardFilters方法返回的SQL以换行符结尾
- 添加测试用例验证redemptionFilters方法返回的SQL以换行符结尾
- 确保兑换记录筛选条件后保留换行符，避免与排序子句黏连